### PR TITLE
Removes Roadmap section form README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ end
 
 The project documentation can be found [here](https://hexdocs.pm/cronex/api-reference.html).
 
-## Roadmap
-
-- [ ] Add logging 
-- [ ] Add support for different time zones
-- [ ] Improve multi node support and control 
-
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jbernardo95/cronex.


### PR DESCRIPTION
This commit removes the Roadmap section in the README.md in favour of
using GitHub issues to track work to be done.