### PR TITLE
Removes ping_interval from configuration files

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,3 +1,1 @@
 use Mix.Config
-
-config :cronex, :ping_interval, 30000

--- a/config/production.exs
+++ b/config/production.exs
@@ -1,3 +1,1 @@
 use Mix.Config
-
-config :cronex, :ping_interval, 30000

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,1 @@
 use Mix.Config
-
-config :cronex, :ping_interval, 100

--- a/lib/cronex/scheduler.ex
+++ b/lib/cronex/scheduler.ex
@@ -30,14 +30,10 @@ defmodule Cronex.Scheduler do
       end
 
       @doc false
-      def job_supervisor do
-        :"#{__MODULE__}.JobSupervisor"
-      end
+      def job_supervisor, do: :"#{__MODULE__}.JobSupervisor"
 
       @doc false
-      def table do
-        :"#{__MODULE__}.Table"
-      end
+      def table, do: :"#{__MODULE__}.Table"
     end
   end
 

--- a/lib/cronex/table.ex
+++ b/lib/cronex/table.ex
@@ -31,12 +31,14 @@ defmodule Cronex.Table do
 
   # Callback functions
   def init(args) do
-    if is_nil(args[:scheduler]), do: raise_scheduler_not_provided_error()
+    scheduler = args[:scheduler]
+
+    if is_nil(scheduler), do: raise_scheduler_not_provided_error()
 
     GenServer.cast(self(), :init)
 
     state = %{
-      scheduler: args[:scheduler],
+      scheduler: scheduler,
       jobs: Map.new(),
       timer: new_ping_timer(),
       leader: false
@@ -130,11 +132,7 @@ defmodule Cronex.Table do
     put_in(state, [:jobs, index], job)
   end
 
-  defp new_ping_timer() do
-    Process.send_after(self(), :ping, ping_interval())
-  end
+  defp new_ping_timer, do: Process.send_after(self(), :ping, ping_interval())
 
-  defp ping_interval do
-    Application.get_env(:cronex, :ping_interval, 30000)
-  end
+  defp ping_interval, do: Application.get_env(:cronex, :ping_interval, 30000)
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,6 @@
 Cronex.Test.DateTime.start_link()
+
 Application.put_env(:cronex, :date_time_provider, Cronex.Test.DateTime)
+Application.put_env(:cronex, :ping_interval, 100)
 
 ExUnit.start()


### PR DESCRIPTION
This PR removes the ping_interval configuration parameter as it does
not make sense to configure it other than in a test environment.

Instead it adds a Cronex.Scheduler.ping_interval/0 function that
returns a fixed ping_interval. This function is used as a replacement to
get the ping_interval value.

In testing the Cronex.Scheduler.ping_interval/0 function is overwritten
to return the desired ping_interval.