### PR TITLE
Fixes syntax error in Cronex.Every documentation

### DIFF
--- a/lib/cronex/every.ex
+++ b/lib/cronex/every.ex
@@ -14,11 +14,11 @@ defmodule Cronex.Every do
 
   ## Example
 
-      every :day, do
+      every :day do
         # Daily task here 
       end
 
-      every :month, do
+      every :month do
         # Monthly task here 
       end
   """
@@ -61,11 +61,11 @@ defmodule Cronex.Every do
 
   ## Example
 
-      every :day, at: "10:00", do
+      every :day, at: "10:00" do
         # Daily task at 10:00 here 
       end
 
-      every :monday, at: "12:00", do
+      every :monday, at: "12:00" do
         # Monday task at 12:00 here 
       end
 


### PR DESCRIPTION
Hi! it's nice to meet you.

I use Elixir 1.9.4 (compiled with Erlang/OTP 22).
Some examples causes SyntaxError.
unexpected token: do. In case you wanted to write a "do" expression,
you must either use do-blocks or separate the keyword argument with comma.