### PR TITLE
Use Supervisor.init/2 instead of deprecated Supervisor.Spec.supervise/2

### DIFF
--- a/lib/cronex/scheduler.ex
+++ b/lib/cronex/scheduler.ex
@@ -26,7 +26,7 @@ defmodule Cronex.Scheduler do
           worker(Cronex.Table, [[scheduler: __MODULE__], [name: table()]])
         ]
 
-        supervise(children, strategy: :one_for_one)
+        Supervisor.init(children, strategy: :one_for_one)
       end
 
       @doc false


### PR DESCRIPTION
The new Elixir 1.10 will start to give warnings on the use of the deprecated Supervisor.Spec.supervise/2. This prevents building with the `--warnings-as-errors` flag on projects that use Cronex.